### PR TITLE
Testsuite changes

### DIFF
--- a/test/blas.jl
+++ b/test/blas.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 
 CUDA.CUBLAS.cublasSetMathMode(CUBLAS.handle(), CUBLAS.CUBLAS_TENSOR_OP_MATH)
 
-@testset "BLAS API" begin
+@test_if "blas" @testset "BLAS API" begin
     @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' ))" for transpose_a = [false, true],
         transpose_b = [false, true]
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
     @test_if "wmma" @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' ))" for transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 128), (128, 128, 256), (256, 256, 256)]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 128), (128, 128, 256), (256, 256, 256), (2048, 2048, 2048)]
             alpha = 2
             beta  = 3
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
     @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' ))" for transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 128), (128, 128, 256), (256, 256, 256), (2048, 2048, 2048)]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 128), (128, 128, 256), (256, 256, 256)]
             alpha = 2
             beta  = 3
 
@@ -54,7 +54,7 @@ using LinearAlgebra
     @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' )) + bias" for transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (4096, 4096, 4096)]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256)]
             a_h = rand(Float16, (M, K)) / sqrt(Float16(K))
             b_h = rand(Float16, (K, N)) / sqrt(Float16(K))
             c_h = rand(Float32, (M, N))
@@ -101,7 +101,7 @@ using LinearAlgebra
     end
 
     @testset "WMMA GEMM (A = diagonal, B = $( !transpose_b ? 'N' : 'T' ))" for transpose_b = [false, true]
-        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256), (2048, 2048, 2048), (4096, 4096, 4096)]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256)]
             @assert M == K "Diagonal only supports square A matrix (M == K)"
 
             transpose_a = false
@@ -161,7 +161,7 @@ using LinearAlgebra
         transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) = [(128, 128, 128), (2048, 2048, 2048)]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) = [(128, 128, 128), (256, 256, 256)]
             a_h = rand(Complex{Float16}, (M, K)) / sqrt(Float16(K));
             b_h = rand(Complex{Float16}, (K, N)) / sqrt(Float16(K));
             c_h = rand(Complex{Float32}, (M, N));
@@ -228,7 +228,7 @@ using LinearAlgebra
     end
 
     @testset "WMMA Dual GEMM" begin
-        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (2048, 2048, 2048)]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256)]
             a_h = rand(Complex{Float16}, (M, K)) / sqrt(Float16(K));
             b_h = rand(Complex{Float16}, (K, N)) / sqrt(Float16(K));
             c_h = rand(Complex{Float32}, (M, N));

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -6,7 +6,7 @@ using LinearAlgebra
 ################################################################################
 
 @testset "Matmul API" begin
-    @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' ))" for transpose_a = [false, true],
+    @test_if "wmma" @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' ))" for transpose_a = [false, true],
         transpose_b = [false, true]
 
         @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 128), (128, 128, 256), (256, 256, 256)]
@@ -51,7 +51,7 @@ using LinearAlgebra
         end
     end
 
-    @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' )) + bias" for transpose_a = [false, true],
+    @test_if "bias" @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' )) + bias" for transpose_a = [false, true],
         transpose_b = [false, true]
 
         @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256)]
@@ -100,7 +100,7 @@ using LinearAlgebra
         end
     end
 
-    @testset "WMMA GEMM (A = diagonal, B = $( !transpose_b ? 'N' : 'T' ))" for transpose_b = [false, true]
+    @test_if "diagonal" @testset "WMMA GEMM (A = diagonal, B = $( !transpose_b ? 'N' : 'T' ))" for transpose_b = [false, true]
         @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256)]
             @assert M == K "Diagonal only supports square A matrix (M == K)"
 
@@ -156,7 +156,7 @@ using LinearAlgebra
         return d[(conjugate, transpose)]
     end
 
-    @testset "WMMA Complex GEMM ($( complex_transform_to_letter(conjugate_a, transpose_a) )$( complex_transform_to_letter(conjugate_b, transpose_b) ))" for conjugate_a = [false, true],
+    @test_if "complex" @testset "WMMA Complex GEMM ($( complex_transform_to_letter(conjugate_a, transpose_a) )$( complex_transform_to_letter(conjugate_b, transpose_b) ))" for conjugate_a = [false, true],
         conjugate_b = [false, true],
         transpose_a = [false, true],
         transpose_b = [false, true]
@@ -227,7 +227,7 @@ using LinearAlgebra
         end
     end
 
-    @testset "WMMA Dual GEMM" begin
+    @test_if "dual" @testset "WMMA Dual GEMM" begin
         @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256)]
             a_h = rand(Complex{Float16}, (M, K)) / sqrt(Float16(K));
             b_h = rand(Complex{Float16}, (K, N)) / sqrt(Float16(K));

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -9,10 +9,7 @@ using LinearAlgebra
     @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' ))" for transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for M in [128, 256],
-            N in [128, 256],
-            K in [128, 256]
-
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 128), (128, 128, 256), (256, 256, 256), (2048, 2048, 2048)]
             alpha = 2
             beta  = 3
 
@@ -30,17 +27,17 @@ using LinearAlgebra
             d   = similar(c)
 
             conf = GemmKernels.get_config(
-                gemm_shape = (M = M, N = N, K = K),
-                operator = Operator.WMMAOp{16, 16, 16},
-                global_a_layout = transpose_a ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
-                global_b_layout = transpose_b ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
+                                          gemm_shape = (M = M, N = N, K = K),
+                                          operator = Operator.WMMAOp{16, 16, 16},
+                                          global_a_layout = transpose_a ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
+                                          global_b_layout = transpose_b ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
 
-                global_c_layout = Layout.AlignedColMajor{Float32},
-                global_d_layout = Layout.AlignedColMajor{Float32},
+                                          global_c_layout = Layout.AlignedColMajor{Float32},
+                                          global_d_layout = Layout.AlignedColMajor{Float32},
 
-                is_a_col_major = !transpose_a,
-                is_b_col_major = !transpose_b,
-                                    )
+                                          is_a_col_major = !transpose_a,
+                                          is_b_col_major = !transpose_b,
+                                         )
 
             GemmKernels.matmul(a, b, c, d, conf;
                                transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
@@ -57,10 +54,7 @@ using LinearAlgebra
     @testset "WMMA GEMM ($( !transpose_a ? 'N' : 'T' )$( !transpose_b ? 'N' : 'T' )) + bias" for transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for M in [128, 256],
-            N in [128, 256],
-            K in [128, 256]
-
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (4096, 4096, 4096)]
             a_h = rand(Float16, (M, K)) / sqrt(Float16(K))
             b_h = rand(Float16, (K, N)) / sqrt(Float16(K))
             c_h = rand(Float32, (M, N))
@@ -83,17 +77,17 @@ using LinearAlgebra
             ep = Epilogue.Bias(pointer(bias))
 
             conf = GemmKernels.get_config(
-                gemm_shape = (M = M, N = N, K = K),
-                operator = Operator.WMMAOp{16, 16, 16},
-                global_a_layout = transpose_a ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
-                global_b_layout = transpose_b ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
+                                          gemm_shape = (M = M, N = N, K = K),
+                                          operator = Operator.WMMAOp{16, 16, 16},
+                                          global_a_layout = transpose_a ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
+                                          global_b_layout = transpose_b ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
 
-                global_c_layout = Layout.AlignedColMajor{Float32},
-                global_d_layout = Layout.AlignedColMajor{Float32},
+                                          global_c_layout = Layout.AlignedColMajor{Float32},
+                                          global_d_layout = Layout.AlignedColMajor{Float32},
 
-                is_a_col_major = !transpose_a,
-                is_b_col_major = !transpose_b,
-                                    )
+                                          is_a_col_major = !transpose_a,
+                                          is_b_col_major = !transpose_b,
+                                         )
 
             GemmKernels.matmul(a, b, c, d, conf;
                                epilogue = ep)
@@ -107,9 +101,8 @@ using LinearAlgebra
     end
 
     @testset "WMMA GEMM (A = diagonal, B = $( !transpose_b ? 'N' : 'T' ))" for transpose_b = [false, true]
-        @testset "(M = $M, N = $N, K = $K)" for M in [128, 256],
-            N in [128, 256],
-            K in [M]
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (256, 256, 256), (2048, 2048, 2048), (4096, 4096, 4096)]
+            @assert M == K "Diagonal only supports square A matrix (M == K)"
 
             transpose_a = false
 
@@ -127,19 +120,19 @@ using LinearAlgebra
             d   = similar(c)
 
             conf = GemmKernels.get_config(
-                gemm_shape = (M = M, N = N, K = K),
-                operator = Operator.WMMAOp{16, 16, 16},
-                global_a_layout = Layout.Diagonal{Float16},
-                global_b_layout = transpose_b ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
+                                          gemm_shape = (M = M, N = N, K = K),
+                                          operator = Operator.WMMAOp{16, 16, 16},
+                                          global_a_layout = Layout.Diagonal{Float16},
+                                          global_b_layout = transpose_b ? Layout.AlignedRowMajor{Float16} : Layout.AlignedColMajor{Float16},
 
-                global_c_layout = Layout.AlignedColMajor{Float32},
-                global_d_layout = Layout.AlignedColMajor{Float32},
+                                          global_c_layout = Layout.AlignedColMajor{Float32},
+                                          global_d_layout = Layout.AlignedColMajor{Float32},
 
-                shared_a_layout = Layout.Padded{Layout.AlignedColMajor{Float16}, 8},
+                                          shared_a_layout = Layout.Padded{Layout.AlignedColMajor{Float16}, 8},
 
-                is_a_col_major = !transpose_a,
-                is_b_col_major = !transpose_b,
-                                    )
+                                          is_a_col_major = !transpose_a,
+                                          is_b_col_major = !transpose_b,
+                                         )
 
             GemmKernels.matmul(a, b, c, d, conf)
 
@@ -168,10 +161,7 @@ using LinearAlgebra
         transpose_a = [false, true],
         transpose_b = [false, true]
 
-        @testset "(M = $M, N = $N, K = $K)" for M in [128, 256],
-            N in [128, 256],
-            K in [128, 256]
-
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) = [(128, 128, 128), (2048, 2048, 2048)]
             a_h = rand(Complex{Float16}, (M, K)) / sqrt(Float16(K));
             b_h = rand(Complex{Float16}, (K, N)) / sqrt(Float16(K));
             c_h = rand(Complex{Float32}, (M, N));
@@ -186,43 +176,43 @@ using LinearAlgebra
             d = similar(c);
 
             conf = GemmKernels.get_config(
-                    gemm_shape = (M = M, N = N, K = K),
-                    operator = Operator.WMMAComplexOp{16, 16, 16},
+                                          gemm_shape = (M = M, N = N, K = K),
+                                          operator = Operator.WMMAComplexOp{16, 16, 16},
 
-                    global_a_layout = transpose_a ? Layout.InterleavedRowMajor{Float16} : Layout.InterleavedColMajor{Float16},
-                    global_b_layout = transpose_b ? Layout.InterleavedRowMajor{Float16} : Layout.InterleavedColMajor{Float16},
-                    global_c_layout = Layout.InterleavedColMajor{Float32},
-                    global_d_layout = Layout.InterleavedColMajor{Float32},
+                                          global_a_layout = transpose_a ? Layout.InterleavedRowMajor{Float16} : Layout.InterleavedColMajor{Float16},
+                                          global_b_layout = transpose_b ? Layout.InterleavedRowMajor{Float16} : Layout.InterleavedColMajor{Float16},
+                                          global_c_layout = Layout.InterleavedColMajor{Float32},
+                                          global_d_layout = Layout.InterleavedColMajor{Float32},
 
-                    shared_a_layout = transpose_a ? Layout.Padded{Layout.SplitRowMajor{Float16}, 8} : Layout.Padded{Layout.SplitColMajor{Float16}, 8},
-                    shared_b_layout = transpose_b ? Layout.Padded{Layout.SplitRowMajor{Float16}, 8} : Layout.Padded{Layout.SplitColMajor{Float16}, 8},
-                    shared_c_layout = Layout.SplitColMajor{Float32},
-                    shared_d_layout = Layout.SplitColMajor{Float32},
+                                          shared_a_layout = transpose_a ? Layout.Padded{Layout.SplitRowMajor{Float16}, 8} : Layout.Padded{Layout.SplitColMajor{Float16}, 8},
+                                          shared_b_layout = transpose_b ? Layout.Padded{Layout.SplitRowMajor{Float16}, 8} : Layout.Padded{Layout.SplitColMajor{Float16}, 8},
+                                          shared_c_layout = Layout.SplitColMajor{Float32},
+                                          shared_d_layout = Layout.SplitColMajor{Float32},
 
-                    warps_per_block = 8,
+                                          warps_per_block = 8,
 
-                    compute_warp = (M = 16, N = 32, K = 16),
+                                          compute_warp = (M = 16, N = 32, K = 16),
 
-                    block_shape = (M = 64, N = 64, K = 32),
+                                          block_shape = (M = 64, N = 64, K = 32),
 
-                    mem_a_warp = transpose_a ? (M = 4, K = 32) : (M = 64, K = 2),
-                    mem_b_warp = transpose_b ? (K = 2, N = 64) : (K = 32, N = 4),
-                    mem_cd_warp = (M = 64, N = 1),
+                                          mem_a_warp = transpose_a ? (M = 4, K = 32) : (M = 64, K = 2),
+                                          mem_b_warp = transpose_b ? (K = 2, N = 64) : (K = 32, N = 4),
+                                          mem_cd_warp = (M = 64, N = 1),
 
-                    mem_a_thread = transpose_a ? (M = 1, K = 4) : (M = 4, K = 1),
-                    mem_b_thread = transpose_b ? (K = 1, N = 4) : (K = 4, N = 1),
-                    mem_cd_thread = (M = 2, N = 1),
+                                          mem_a_thread = transpose_a ? (M = 1, K = 4) : (M = 4, K = 1),
+                                          mem_b_thread = transpose_b ? (K = 1, N = 4) : (K = 4, N = 1),
+                                          mem_cd_thread = (M = 2, N = 1),
 
-                    is_a_col_major = !transpose_a,
-                    is_b_col_major = !transpose_b
-                )
+                                          is_a_col_major = !transpose_a,
+                                          is_b_col_major = !transpose_b
+                                         )
 
             trans_a = conjugate_a ? Transform.Elementwise(conj) : Transform.Elementwise()
             trans_b = conjugate_b ? Transform.Elementwise(conj) : Transform.Elementwise()
 
             GemmKernels.matmul(a, b, c, d, conf;
-                            transform_global_to_shared_a = trans_a,
-                            transform_global_to_shared_b = trans_b)
+                               transform_global_to_shared_a = trans_a,
+                               transform_global_to_shared_b = trans_b)
 
             new_a_h = conjugate_a ? conj.(a_h) : a_h
             new_b_h = conjugate_b ? conj.(b_h) : b_h
@@ -238,10 +228,7 @@ using LinearAlgebra
     end
 
     @testset "WMMA Dual GEMM" begin
-        @testset "(M = $M, N = $N, K = $K)" for M in [128, 256],
-            N in [128, 256],
-            K in [128, 256]
-
+        @testset "(M = $M, N = $N, K = $K)" for (M, N, K) in [(128, 128, 128), (2048, 2048, 2048)]
             a_h = rand(Complex{Float16}, (M, K)) / sqrt(Float16(K));
             b_h = rand(Complex{Float16}, (K, N)) / sqrt(Float16(K));
             c_h = rand(Complex{Float32}, (M, N));
@@ -252,33 +239,33 @@ using LinearAlgebra
             d = similar(c);
 
             conf = GemmKernels.get_config(
-                    gemm_shape = (M = M, N = N, K = K),
-                    operator = Operator.WMMADualOp{16, 16, 16},
+                                          gemm_shape = (M = M, N = N, K = K),
+                                          operator = Operator.WMMADualOp{16, 16, 16},
 
-                    global_a_layout = Layout.InterleavedColMajor{Float16},
-                    global_b_layout = Layout.InterleavedColMajor{Float16},
-                    global_c_layout = Layout.InterleavedColMajor{Float32},
-                    global_d_layout = Layout.InterleavedColMajor{Float32},
+                                          global_a_layout = Layout.InterleavedColMajor{Float16},
+                                          global_b_layout = Layout.InterleavedColMajor{Float16},
+                                          global_c_layout = Layout.InterleavedColMajor{Float32},
+                                          global_d_layout = Layout.InterleavedColMajor{Float32},
 
-                    shared_a_layout = Layout.Padded{Layout.SplitColMajor{Float16}, 8},
-                    shared_b_layout = Layout.Padded{Layout.SplitColMajor{Float16}, 8},
-                    shared_c_layout = Layout.SplitColMajor{Float32},
-                    shared_d_layout = Layout.SplitColMajor{Float32},
+                                          shared_a_layout = Layout.Padded{Layout.SplitColMajor{Float16}, 8},
+                                          shared_b_layout = Layout.Padded{Layout.SplitColMajor{Float16}, 8},
+                                          shared_c_layout = Layout.SplitColMajor{Float32},
+                                          shared_d_layout = Layout.SplitColMajor{Float32},
 
-                    warps_per_block = 8,
+                                          warps_per_block = 8,
 
-                    compute_warp = (M = 16, N = 32, K = 16),
+                                          compute_warp = (M = 16, N = 32, K = 16),
 
-                    block_shape = (M = 64, N = 64, K = 32),
+                                          block_shape = (M = 64, N = 64, K = 32),
 
-                    mem_a_warp = (M = 64, K = 2),
-                    mem_b_warp = (K = 32, N = 4),
-                    mem_cd_warp = (M = 64, N = 1),
+                                          mem_a_warp = (M = 64, K = 2),
+                                          mem_b_warp = (K = 32, N = 4),
+                                          mem_cd_warp = (M = 64, N = 1),
 
-                    mem_a_thread = (M = 4, K = 1),
-                    mem_b_thread = (K = 4, N = 1),
-                    mem_cd_thread = (M = 2, N = 1)
-                )
+                                          mem_a_thread = (M = 4, K = 1),
+                                          mem_b_thread = (K = 4, N = 1),
+                                          mem_cd_thread = (M = 2, N = 1)
+                                         )
 
             GemmKernels.matmul(a, b, c, d, conf)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test
 macro test_if(label, expr)
     return quote
         if isempty(ARGS) || $(label) in ARGS
-            $(expr)
+            $(esc(expr))
         else
             nothing
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,16 @@
 using GemmKernels
 using Test
 
+macro test_if(label, expr)
+    return quote
+        if isempty(ARGS) || $(label) in ARGS
+            $(expr)
+        else
+            nothing
+        end
+    end
+end
+
 @testset "GemmKernels.jl" begin
     include("tiling.jl")
     include("matmul.jl")

--- a/test/tiling.jl
+++ b/test/tiling.jl
@@ -2,7 +2,7 @@ using GemmKernels.Tiling
 
 ################################################################################
 
-@testset "Tiling API" begin
+@test_if "tiling" @testset "Tiling API" begin
     @testset "Tiles" begin
         @testset "Index" begin
             @test Tile(M = 4, N = 4, K = 4).index == (M = 0, N = 0, K = 0)


### PR DESCRIPTION
- Allow only executing some tests with command line arguments to `runtests.jl`
- Disable conjugation in tests
- Reduce number of different matrix sizes that are tested